### PR TITLE
创建Object分行排列时逗号前置

### DIFF
--- a/style.md
+++ b/style.md
@@ -138,9 +138,8 @@
 
     ```
     var a = ['hello', 'world'];
-    var b = {
-      good: 'code',
-      'is generally': 'pretty',
+    var b = {"good": 'code'
+      , is generally: 'pretty'
     };
     ```
       
@@ -149,9 +148,10 @@
     ```
     var a = [
       'hello', 'world'
-    ];
-    var b = {"good": 'code'
-      , is generally: 'pretty'
+    ];    
+    var b = {
+      good: 'code',
+      'is generally': 'pretty',
     };
     ```
 


### PR DESCRIPTION
觉得创建Object分行排列时逗号前置较好，这样不管key和value多长，逗号总是对齐的，便于发现missing comma。例子可以参见一些node框架，如express, socketio, mongoose等。
